### PR TITLE
add package stub with env hooks for ROS_VERSION and ROS_DISTRO

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,20 @@
+cmake_minimum_required(VERSION 2.8.3)
+project(ros_environment)
+find_package(catkin REQUIRED)
+
+catkin_package()
+
+if(CMAKE_HOST_UNIX)
+  set(shells "sh")
+else()
+  set(shells "bat")
+endif()
+
+set(
+  hooks
+  "1.ros_distro"
+  "1.ros_version"
+)
+foreach(hook ${hooks})
+  catkin_add_env_hooks("${hook}" SHELLS ${shells} DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/env-hooks)
+endforeach()

--- a/env-hooks/1.ros_distro.bat
+++ b/env-hooks/1.ros_distro.bat
@@ -1,0 +1,3 @@
+REM copied from ros_environment/env-hooks/1.ros_distro.bat
+
+set ROS_DISTRO=TODO

--- a/env-hooks/1.ros_distro.sh.em
+++ b/env-hooks/1.ros_distro.sh.em
@@ -1,0 +1,13 @@
+# generated from ros_environment/env-hooks/1.ros_distro.sh.em
+
+@{
+# This is a build-time environment variable which allows a build engineer to override the expected
+# ROS_DISTRO value for a workspace, for example to deliberately use a newer version of roslib with
+# an older release or vice-versa, or to define a custom distro (eg, "ROS Banana").
+from os import environ
+ROS_DISTRO = environ.get("ROS_DISTRO_OVERRIDE", "TODO")
+}@
+if [ -n "$ROS_DISTRO" -a "$ROS_DISTRO" != "@(ROS_DISTRO)" ]; then
+  echo "ROS_DISTRO was set to '$ROS_DISTRO' before. Please make sure that the environment does not mix paths from different distributions."
+fi
+export ROS_DISTRO=@(ROS_DISTRO)

--- a/env-hooks/1.ros_version.bat
+++ b/env-hooks/1.ros_version.bat
@@ -1,0 +1,3 @@
+REM copied from ros_environment/env-hooks/1.ros_version.bat
+
+set ROS_VERSION=TODO

--- a/env-hooks/1.ros_version.sh
+++ b/env-hooks/1.ros_version.sh
@@ -1,0 +1,3 @@
+# copied from ros_environment/env-hooks/1.ros_version.sh
+
+export ROS_VERSION=TODO

--- a/package.xml
+++ b/package.xml
@@ -1,0 +1,12 @@
+<package>
+  <name>ros_environment</name>
+  <version>0.0.0</version>
+  <description>The package provides the environment variables `ROS_VERSION` and `ROS_DISTRO`.</description>
+  <maintainer email="dthomas@osrfoundation.org">Dirk Thomas</maintainer>
+  <license>Apache License 2.0</license>
+
+  <url type="repository">https://github.com/ros/ros_environment</url>
+  <url type="bugtracker">https://github.com/ros/ros_environment/issues</url>
+
+  <buildtool_depend>catkin</buildtool_depend>
+</package>


### PR DESCRIPTION
This PR adds the stub of the package.

After it has been reviewed and merged I will:

* create an `ardent` specific branch, replace `catkin` usage with `ament_cmake`, and replace the `TODO`s with `2` and `ardent` (see #3)
* create a follow up PR to add an environment variable `ROS_PACKAGE_PATH` used in ROS 1 (see #2)
  * create ROS 1 distro specific branches and replace the `TODO`s with `1` and `melodic` / `lunar` / `kinetic`