### PR TITLE
remove os.path.normcase

### DIFF
--- a/env-hooks/1.ros_package_path.bat.em
+++ b/env-hooks/1.ros_package_path.bat.em
@@ -8,7 +8,7 @@ echo import os >> _parent_package_path.py
 echo env_name = 'CMAKE_PREFIX_PATH' >> _parent_package_path.py
 echo paths = [path for path in os.environ[env_name].split(os.pathsep)] if env_name in os.environ and os.environ[env_name] != '' else [] >> _parent_package_path.py
 echo workspaces = [path for path in paths if os.path.exists(os.path.join(path, '.catkin'))] >> _parent_package_path.py
-echo workspaces = list(set([os.path.normpath(os.path.normcase(ws)) for ws in workspaces])) >> _parent_package_path.py
+echo workspaces = list(set([os.path.normpath(ws) for ws in workspaces])) >> _parent_package_path.py
 echo paths = [] >> _parent_package_path.py
 echo for workspace in workspaces: >> _parent_package_path.py
 echo     filename = os.path.join(workspace, '.catkin') >> _parent_package_path.py


### PR DESCRIPTION
`os.path.normcase` will change `C:\path1\path2` to `c:\path1\path2`. Most (all) of paths comparisons in ROS core stacks are doing case-sensitive string comparison so this would lead to errors later on.

Given Windows is a case-insensitive system, `os.path.normpath(os.path.normcase())` is actually good since it makes sure to give a unique path, and this change should not bring in any side effect.

However, it requires all path comparisons in ROS (core stacks) to use `os.path.normpath(os.path.normcase())` for string comparison. While this could eventually be the right thing to do, that change would be of a much larger scale, and requires a much longer time before it gets consumed and tested.