### PR TITLE
[Windows][melodic] Use stable ordered methods to build %ROS_PACKAGE_PATH%.

### DIFF
--- a/env-hooks/1.ros_package_path.bat.em
+++ b/env-hooks/1.ros_package_path.bat.em
@@ -5,10 +5,11 @@ REM do not use EnableDelayedExpansion here, it messes with the != symbols
 setlocal disabledelayedexpansion
 echo from __future__ import print_function > _parent_package_path.py
 echo import os >> _parent_package_path.py
+echo from collections import OrderedDict >> _parent_package_path.py
 echo env_name = 'CMAKE_PREFIX_PATH' >> _parent_package_path.py
 echo paths = [path for path in os.environ[env_name].split(os.pathsep)] if env_name in os.environ and os.environ[env_name] != '' else [] >> _parent_package_path.py
 echo workspaces = [path for path in paths if os.path.exists(os.path.join(path, '.catkin'))] >> _parent_package_path.py
-echo workspaces = list(set([os.path.normpath(ws) for ws in workspaces])) >> _parent_package_path.py
+echo workspaces = list(OrderedDict.fromkeys([os.path.normpath(ws) for ws in workspaces])) >> _parent_package_path.py
 echo paths = [] >> _parent_package_path.py
 echo for workspace in workspaces: >> _parent_package_path.py
 echo     filename = os.path.join(workspace, '.catkin') >> _parent_package_path.py


### PR DESCRIPTION
On Windows, currently we use [`set`](https://docs.python.org/2/library/stdtypes.html#set) to avoid workspace duplicates in the final %ROS_PACKAGE_PATH%. However, one big drawback is that it doesn't preserve the order of the workspace originally being sourced, and it came back to us as devel space bug like this: https://github.com/ms-iot/ROSOnWindows/issues/83

In this pull request, I am proposing to use a stable ordered methods [`OrderedDict.fromkeys`](https://docs.python.org/2/library/collections.html#ordereddict-objects) to construct a set to preserve the correct order.