### PR TITLE
Noetic defaults to Python3

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -10,14 +10,14 @@ set(ROS_VERSION "1")
 if(DEFINED ENV{ROS_PYTHON_VERSION})
   set(ROS_PYTHON_VERSION "$ENV{ROS_PYTHON_VERSION}")
 else()
-  set(ROS_PYTHON_VERSION "2")
+  set(ROS_PYTHON_VERSION "3")
 endif()
 
 # allow overriding the distro name
 if(DEFINED ENV{ROS_DISTRO_OVERRIDE})
   set(ROS_DISTRO $ENV{ROS_DISTRO_OVERRIDE})
 else()
-  set(ROS_DISTRO "melodic")
+  set(ROS_DISTRO "noetic")
 endif()
 
 set(


### PR DESCRIPTION
I made a `noetic` branch from the `melodic` one, and this is a PR to update it. I did not bump the `package.xml` version as I figured that would be done during release.