### PR TITLE
Output ROS_DISTRO warning to stderr

### DIFF
--- a/env-hooks/0.ros_distro_check.sh.in
+++ b/env-hooks/0.ros_distro_check.sh.in
@@ -1,5 +1,5 @@
 # generated from ros_environment/env-hooks/0.ros_distro.sh.in
 
 if [ -n "$ROS_DISTRO" -a "$ROS_DISTRO" != "@ROS_DISTRO@" ]; then
-  echo "ROS_DISTRO was set to '$ROS_DISTRO' before. Please make sure that the environment does not mix paths from different distributions."
+  echo "ROS_DISTRO was set to '$ROS_DISTRO' before. Please make sure that the environment does not mix paths from different distributions." >&2
 fi


### PR DESCRIPTION
It's unusual for scripts to look at the output of sourcing an environment file, but it did happen in https://github.com/RobotLocomotion/drake-ros/issues/53 .

Outputting to stderr seems to match POSIX documentation which says stderr is `[...] for writing diagnostic output`.

https://pubs.opengroup.org/onlinepubs/9699919799/functions/stderr.html

Signed-off-by: Shane Loretz <sloretz@osrfoundation.org>