### PR TITLE
Ros distro humble

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -10,7 +10,7 @@ set(ROS_PYTHON_VERSION "3")
 if(DEFINED ENV{ROS_DISTRO_OVERRIDE})
   set(ROS_DISTRO $ENV{ROS_DISTRO_OVERRIDE})
 else()
-  set(ROS_DISTRO "rolling")
+  set(ROS_DISTRO "humble")
 endif()
 
 set(


### PR DESCRIPTION
After installing humble ros from binaries, running

```
source /opt/ros/humble/setup.bash
echo $ROS_DISTRO
```

Returns

```
rolling
```

It should return ``humble``.