### PR TITLE
fix cmake deprecation

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.5)
+cmake_minimum_required(VERSION 3.15)
 project(ros_environment NONE)
 find_package(ament_cmake_core REQUIRED)
 


### PR DESCRIPTION
cmake <=3.5 is deprecated in cmake version 4
ros rolling require cmake 3.15